### PR TITLE
Fix a typo in README

### DIFF
--- a/README
+++ b/README
@@ -24,6 +24,6 @@
 # Boot partition, kernel & ramdisk
   device/brcm/rpi2/boot/* to p1:/
   kernel/rpi/arch/arm/boot/zImage to p1:/
-  kernel/rpi/arch/arm/boot/dts/bcm2709-rpi2-b.dtb to p1:/
+  kernel/rpi/arch/arm/boot/dts/bcm2709-rpi-2-b.dtb to p1:/
   out/target/product/rpi2/ramdisk.img to p1:/
 


### PR DESCRIPTION
Many thanks for your efforts. I compiled the code and successfully installed the OS to my Pi II.
But when I do the installation according to the README, I find the .dtb file path given is wrong, and here is the fix.