### PR TITLE
default clock speeds to 900mhz

### DIFF
--- a/boot/config.txt
+++ b/boot/config.txt
@@ -11,4 +11,5 @@ device_tree=bcm2709-rpi-2-b.dtb
 initramfs ramdisk.img 0x01f00000
 mask_gpu_interrupt0=0x400
 avoid_warnings=2
-
+arm_freq=900
+force_turbo=1


### PR DESCRIPTION
setting force_turbo=1 and arm_freq=900 will allow us to override whatever is setting the clock to 600mhz instead of default 900mhz. This work around is also used by MS in the Windows 10 IoT for raspberry pi so we should be good in terms of force_turbo=1 harming the device in any manner.